### PR TITLE
Add support for Storm 0.9.3 and Zookeeper 3.4.6 and fix g++ unmet dependencies issue for ZeroMQ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 .settings
 conf/configuration.yaml
 conf/credential.yaml
+dependency-reduced-pom.xml
+memory-monitor.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+/target/
+.classpath
+.project
+.settings
+conf/configuration.yaml
+conf/credential.yaml

--- a/README.markdown
+++ b/README.markdown
@@ -12,8 +12,8 @@ I am working on adding support for deploying on [Apache CloudStack](http://cloud
 + Automatically sets up s3cmd, making it easy to get/put files on [Amazon S3](http://aws.amazon.com/s3/)
 + Automatically sets up [Ganglia](http://ganglia.sourceforge.net/), making it easy to monitor performance
 + Automatically sets up [Amazon EC2 AMI Tools](http://docs.aws.amazon.com/AWSEC2/latest/CommandLineReference/ami-tools.html) on new nodes
-+ Supports Zookeeper versions: _3.3.3_ & _3.4.5_
-+ Supports Storm versions: _0.8.2_ & _0.9.0.1_ & _0.9.2_
++ Supports Zookeeper versions: _3.3.3_ & _3.4.5_ & _3.4.6_
++ Supports Storm versions: _0.8.2_ & _0.9.0.1_ & _0.9.2_ & _0.9.3_
 
 ## Configuration
 This tool, requires two configurationfiles: `conf/credential.yaml` and `conf/configuration.yaml`. Put your credentials into the file `conf/credential.yaml`. 

--- a/src/dk/kaspergsm/stormdeploy/configurations/NodeConfiguration.java
+++ b/src/dk/kaspergsm/stormdeploy/configurations/NodeConfiguration.java
@@ -41,7 +41,7 @@ public class NodeConfiguration {
 		commands.addAll(ZeroMQ.download());
 		commands.addAll(ZeroMQ.configure());
 		
-		// Download and configure snorm-deploy-alternative (before anything with supervision is started)
+		// Download and configure storm-deploy-alternative (before anything with supervision is started)
 		commands.addAll(StormDeployAlternative.download());
 		commands.addAll(StormDeployAlternative.writeConfigurationFiles(Tools.getWorkDir() + "conf" + File.separator + "configuration.yaml", Tools.getWorkDir() + "conf" + File.separator + "credential.yaml"));
 		commands.addAll(StormDeployAlternative.writeLocalSSHKeys());

--- a/src/dk/kaspergsm/stormdeploy/configurations/SystemTools.java
+++ b/src/dk/kaspergsm/stormdeploy/configurations/SystemTools.java
@@ -31,6 +31,7 @@ public class SystemTools {
 			
 			// Init apt
 			st.add(exec("apt-get update -y"));
+			st.add(exec("apt-get upgrade -y"));
 			
 			// Install JDK (OpenJDK 7)
 			st.add(exec("apt-get install -y openjdk-7-jdk"));
@@ -44,9 +45,7 @@ public class SystemTools {
 			st.add(exec("apt-get install -y git"));
 			
 			// Install build-tools
-			st.add(exec("apt-get install -y gcc"));
-			st.add(exec("apt-get install -y gcc++"));
-			st.add(exec("apt-get install -y make"));
+			st.add(exec("apt-get install -y build-essential"));
 			st.add(exec("apt-get install -y uuid-dev"));
 			st.add(exec("apt-get install -y pkg-config"));
 			st.add(exec("apt-get install -y libtool"));

--- a/src/dk/kaspergsm/stormdeploy/configurations/Zookeeper.java
+++ b/src/dk/kaspergsm/stormdeploy/configurations/Zookeeper.java
@@ -30,6 +30,8 @@ public class Zookeeper {
 				sb.append("\\n"); // escaped newline
 		}
 		st.add(exec("cd ~/zookeeper/conf/"));
+		st.add(exec("[ ! -e zoo.cfg ] && cp zoo_sample.cfg zoo.cfg && echo -e \"# the zookeeper ensemble\nserver.x\" >> zoo.cfg"));
+		st.add(exec("sed \"s|dataDir=.*|dataDir=/tmp/zktmp|\" -i \"zoo.cfg\""));	// set dataDir to /tmp/zktmp
 		st.add(exec("sed \"s/server.*/server.x/\" -i \"zoo.cfg\""));				// convert each serverline to server.x
 		st.add(exec("sed '$!N; /^\\(.*\\)\\n\\1$/!P; D' -i \"zoo.cfg\""));			// delete duplicate lines => one server.x
 		st.add(exec("sed \"s/server.x/" + sb.toString() + "/\" -i \"zoo.cfg\""));	// replace server.x with new lines

--- a/src/dk/kaspergsm/stormdeploy/configurations/Zookeeper.java
+++ b/src/dk/kaspergsm/stormdeploy/configurations/Zookeeper.java
@@ -14,7 +14,7 @@ import dk.kaspergsm.stormdeploy.Tools;
 public class Zookeeper {
 
 	public static List<Statement> download(String zookeeperRemoteLocation) {
-		return Tools.download("~", zookeeperRemoteLocation, true, true);
+		return Tools.download("~/", zookeeperRemoteLocation, true, true, "zookeeper");
 	}
 
 	public static List<Statement> configure(List<String> zkNodesHostnames) {

--- a/src/dk/kaspergsm/stormdeploy/userprovided/Configuration.java
+++ b/src/dk/kaspergsm/stormdeploy/userprovided/Configuration.java
@@ -268,6 +268,8 @@ public class Configuration {
 			return "https://s3-eu-west-1.amazonaws.com/zk-releases/zookeeper-3.3.3.tar.gz"; 
 		} else if (version.equals("3.4.5")) {
 			return "https://s3-eu-west-1.amazonaws.com/zk-releases/zookeeper-3.4.5.tar.gz";
+		} else if (version.equals("3.4.6")) {
+			return "http://tweedo.com/mirror/apache/zookeeper/zookeeper-3.4.6/zookeeper-3.4.6.tar.gz";
 		} else {
 			log.info("Zookeeper version not currently supported!");
 		}
@@ -285,6 +287,8 @@ public class Configuration {
 			return "https://s3-eu-west-1.amazonaws.com/storm-releases/storm-0.9.0.1.tar.gz";
 		} else if (version.equals("0.9.2")) {
 			return "https://s3-eu-west-1.amazonaws.com/storm-releases/apache-storm-0.9.2-incubating.tar.gz";
+		} else if (version.equals("0.9.3")) {
+			return "http://tweedo.com/mirror/apache/storm/apache-storm-0.9.3/apache-storm-0.9.3.tar.gz";
 		} else {
 			log.info("Storm version " + version + " not currently supported!");
 		}


### PR DESCRIPTION
Hello Kasper,

please have a look at my changes to support Storm 0.9.3 and Zookeeper 3.4.6.
There was also a compilation problem of ZeroMQ because of a g++ unmet dependencies issue.
I fixed it by installing the build-essential instead.

Thanks!
Best regards
Martin