### PR TITLE
updates necessary to run DRPC

### DIFF
--- a/src/dk/kaspergsm/stormdeploy/Tools.java
+++ b/src/dk/kaspergsm/stormdeploy/Tools.java
@@ -150,10 +150,10 @@ public class Tools {
 	
 	/**
 	 * Get ports to open
-	 * 	22 = SSH, 6627 = Thrift, 8080 = UI, 80 = GANGLIA UI, 8000 = Logviewer
+	 * 	22 = SSH, 6627 = Thrift, 8080 = UI, 80 = GANGLIA UI, 8000 = Logviewer, 3772 = DRPC
 	 */
 	public static int[] getPortsToOpen() {
-		return new int[]{22, 6627, 8080, 80, 8000};
+            return new int[]{22, 6627, 8080, 80, 8000, 3772};
 	}
 	
 	@SuppressWarnings("unchecked")

--- a/src/dk/kaspergsm/stormdeploy/commands/Deploy.java
+++ b/src/dk/kaspergsm/stormdeploy/commands/Deploy.java
@@ -91,6 +91,7 @@ public class Deploy {
 							credentials,
 							config, 
 							getNewInstancesPrivateIp(config, "ZK", newNodes), 
+							getNewInstancesPrivateIp(config, "DRPC", newNodes), 
 							getNimbusNode(config, newNodes).getPrivateAddresses().iterator().next(), 
 							getUINode(config, newNodes).getPrivateAddresses().iterator().next()),
 					true,

--- a/src/dk/kaspergsm/stormdeploy/commands/ScaleOutCluster.java
+++ b/src/dk/kaspergsm/stormdeploy/commands/ScaleOutCluster.java
@@ -37,6 +37,7 @@ public class ScaleOutCluster {
 		 */
 		ArrayList<NodeMetadata> existingZookeeper = new ArrayList<NodeMetadata>();
 		ArrayList<NodeMetadata> existingWorkers = new ArrayList<NodeMetadata>();
+		ArrayList<NodeMetadata> existingDRPC = new ArrayList<NodeMetadata>();
 		NodeMetadata nimbus = null, ui = null;
 		String image = null, region = null;
 		for (NodeMetadata n : (Set<NodeMetadata>) computeContext.getComputeService().listNodes()) {			
@@ -55,6 +56,8 @@ public class ScaleOutCluster {
 						existingWorkers.add(n);
 					if (daemon.trim().toLowerCase().equals("zk"))
 						existingZookeeper.add(n);
+					if (daemon.trim().toLowerCase().equals("drpc"))
+						existingDRPC.add(n);
 				}
 				
 				if (image == null)
@@ -75,6 +78,7 @@ public class ScaleOutCluster {
 						credentials, 
 						config, 
 						getInstancesPrivateIp(existingZookeeper), 
+						getInstancesPrivateIp(existingDRPC), 
 						nimbus.getPrivateAddresses().iterator().next(), 
 						ui.getPrivateAddresses().iterator().next()), 
 					instanceType, 

--- a/src/dk/kaspergsm/stormdeploy/configurations/NodeConfiguration.java
+++ b/src/dk/kaspergsm/stormdeploy/configurations/NodeConfiguration.java
@@ -14,7 +14,7 @@ import dk.kaspergsm.stormdeploy.userprovided.Credential;
  */
 public class NodeConfiguration {
 	
-	public static List<Statement> getCommands(String clustername, Credential credentials, Configuration config, List<String> zookeeperHostnames, String nimbusHostname, String uiHostname) {
+	public static List<Statement> getCommands(String clustername, Credential credentials, Configuration config, List<String> zookeeperHostnames, List<String> drpcHostnames, String nimbusHostname, String uiHostname) {
 		List<Statement> commands = new ArrayList<Statement>();
 		
 		// Install system tools
@@ -63,7 +63,7 @@ public class NodeConfiguration {
 		commands.addAll(Zookeeper.configure(zookeeperHostnames));
 		
 		// Configure Storm (update configurationfiles)
-		commands.addAll(Storm.configure(nimbusHostname, zookeeperHostnames, config.getImageUsername()));
+		commands.addAll(Storm.configure(nimbusHostname, zookeeperHostnames, drpcHostnames, config.getImageUsername()));
 		
 		// Configure Ganglia
 		commands.addAll(Ganglia.configure(clustername, uiHostname));
@@ -80,6 +80,7 @@ public class NodeConfiguration {
 		commands.addAll(Storm.startNimbusDaemonSupervision(config.getImageUsername()));
 		commands.addAll(Storm.startSupervisorDaemonSupervision(config.getImageUsername()));
 		commands.addAll(Storm.startUIDaemonSupervision(config.getImageUsername()));
+		commands.addAll(Storm.startDRPCDaemonSupervision(config.getImageUsername()));
 		commands.addAll(Storm.startLogViewerDaemonSupervision(config.getImageUsername()));
 		commands.addAll(Ganglia.start());
 		

--- a/src/dk/kaspergsm/stormdeploy/configurations/Storm.java
+++ b/src/dk/kaspergsm/stormdeploy/configurations/Storm.java
@@ -27,7 +27,7 @@ public class Storm {
 	/**
 	 * Write storm/conf/storm.yaml (basic settings only)
 	 */
-	public static List<Statement> configure(String hostname, List<String> zkNodesHostname, String userName) {
+	public static List<Statement> configure(String hostname, List<String> zkNodesHostname, List<String> drpcHostname, String userName) {
 		ArrayList<Statement> st = new ArrayList<Statement>();
 		st.add(exec("cd ~/storm/conf/"));
 		st.add(exec("touch storm.yaml"));
@@ -39,6 +39,13 @@ public class Storm {
 		st.add(exec("echo storm.zookeeper.servers: >> storm.yaml"));
 		for (int i = 1; i <= zkNodesHostname.size(); i++)
 			st.add(exec("echo - \"" + zkNodesHostname.get(i-1) + "\" >> storm.yaml"));
+
+		// Add drpc.servers
+                if (drpcHostname.size() > 0) {
+                    st.add(exec("echo drpc.servers: >> storm.yaml"));
+                    for (int i = 1; i <= drpcHostname.size(); i++)
+			st.add(exec("echo - \"" + drpcHostname.get(i-1) + "\" >> storm.yaml"));
+                }
 		
 		// Add supervisor metadata
 		st.add(exec("echo supervisor.scheduler.meta: >> storm.yaml"));
@@ -81,6 +88,16 @@ public class Storm {
 		ArrayList<Statement> st = new ArrayList<Statement>();
 		st.add(exec("cd ~"));
 		st.add(exec("su -c 'case $(head -n 1 ~/daemons) in *UI*) java -cp \"sda/storm-deploy-alternative.jar\" dk.kaspergsm.stormdeploy.image.ProcessMonitor backtype.storm.ui.core storm/bin/storm ui ;; esac &' - " + username));
+		return st;
+	}
+	
+	/**
+	 * Uses Monitor to restart daemon, if it stops
+	 */
+	public static List<Statement> startDRPCDaemonSupervision(String username) {
+		ArrayList<Statement> st = new ArrayList<Statement>();
+		st.add(exec("cd ~"));
+		st.add(exec("su -c 'case $(head -n 1 ~/daemons) in *DRPC*) java -cp \"sda/storm-deploy-alternative.jar\" dk.kaspergsm.stormdeploy.image.ProcessMonitor backtype.storm.daemon.drpc storm/bin/storm drpc ;; esac &' - " + username));
 		return st;
 	}
 	

--- a/src/dk/kaspergsm/stormdeploy/userprovided/Configuration.java
+++ b/src/dk/kaspergsm/stormdeploy/userprovided/Configuration.java
@@ -289,6 +289,10 @@ public class Configuration {
 			return "https://s3-eu-west-1.amazonaws.com/storm-releases/apache-storm-0.9.2-incubating.tar.gz";
 		} else if (version.equals("0.9.3")) {
 			return "https://s3-eu-west-1.amazonaws.com/storm-releases/apache-storm-0.9.3.tar.gz";
+		} else if (version.equals("0.9.4")) {
+			return "http://mirror.cogentco.com/pub/apache/storm/apache-storm-0.9.4/apache-storm-0.9.4.tar.gz";
+		} else if (version.equals("0.9.5")) {
+			return "http://mirror.cogentco.com/pub/apache/storm/apache-storm-0.9.5/apache-storm-0.9.5.tar.gz";
 		} else {
 			log.info("Storm version " + version + " not currently supported!");
 		}


### PR DESCRIPTION
Three additions:
  * DRPC is added as a service like ZK, WORKER, LOGVIEWER, etc.
  * drpc.servers section added to storm.yaml
  * Storm 0.9.4 and 0.9.5 added

I encountered a known bug in Storm when trying to use 0.9.3.  This bug is only completely fixed in 0.9.5.  You ordinarily get Storm versions from an S3 bucket, but I don't have access to that bucket, so I used Apache mirror URLs to download these versions of Storm.  I think you'll want to put these versions into your S3 bucket and modify the URLs to point to them.

In my tests, I found that I only needed to have one of my nodes running DRPC.
