### PR TITLE
use Java collection interfaces rather than specific implementation

### DIFF
--- a/src/dk/kaspergsm/stormdeploy/Tools.java
+++ b/src/dk/kaspergsm/stormdeploy/Tools.java
@@ -179,7 +179,7 @@ public class Tools {
 	 * Run set of custom commands
 	 */
 	public static List<Statement> runCustomCommands(List<String> commands) {
-		ArrayList<Statement> st = new ArrayList<Statement>();
+		List<Statement> st = new ArrayList<Statement>();
 		for (String command : commands)
 			st.add(exec(command));
 		return st;
@@ -189,7 +189,7 @@ public class Tools {
 	 * Used to read local file, and echo into remote file
 	 */
 	public static List<Statement> echoFile(String localPath, String remotePath) {
-		ArrayList<Statement> st = new ArrayList<Statement>();
+		List<Statement> st = new ArrayList<Statement>();
 		for (String l : readFile(localPath).split("\n"))
 			st.add(exec("echo '" + l + "' >> " + remotePath));
 		return st;
@@ -204,7 +204,7 @@ public class Tools {
 	 * RemotePath should always be downloadable by wget
 	 */
 	public static List<Statement> download(String localPath, String remotePath, boolean extract, boolean delete, String finalName) {
-		ArrayList<Statement> st = new ArrayList<Statement>();
+		List<Statement> st = new ArrayList<Statement>();
 		st.add(exec("cd " + localPath));
 		
 		// Extract filename
@@ -259,8 +259,8 @@ public class Tools {
 		}
 	}
 	
-	public static List<String> getInstancesIp(ArrayList<NodeMetadata> nodes) {
-		ArrayList<String> newNodes = new ArrayList<String>();
+	public static List<String> getInstancesIp(List<NodeMetadata> nodes) {
+		List<String> newNodes = new ArrayList<String>();
 		for (NodeMetadata n : nodes)
 			newNodes.add(getInstanceIp(n));			
 		return newNodes;

--- a/src/dk/kaspergsm/stormdeploy/commands/Deploy.java
+++ b/src/dk/kaspergsm/stormdeploy/commands/Deploy.java
@@ -5,6 +5,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.Map.Entry;
 import java.util.concurrent.ExecutionException;
@@ -121,7 +123,7 @@ public class Deploy {
 		System.exit(0);
 	}
 	
-	private static NodeMetadata getNimbusNode(Configuration config, HashMap<Integer, NodeMetadata> nodes) {
+	private static NodeMetadata getNimbusNode(Configuration config, Map<Integer, NodeMetadata> nodes) {
 		for (NodeMetadata n : nodes.values()) {
 			if (n.getUserMetadata().containsKey("daemons") && n.getUserMetadata().get("daemons").contains("MASTER"))
 				return n;
@@ -129,7 +131,7 @@ public class Deploy {
 		return null;
 	}
 	
-	private static NodeMetadata getUINode(Configuration config, HashMap<Integer, NodeMetadata> nodes) {
+	private static NodeMetadata getUINode(Configuration config, Map<Integer, NodeMetadata> nodes) {
 		for (NodeMetadata n : nodes.values()) {
 			if (n.getUserMetadata().containsKey("daemons") && n.getUserMetadata().get("daemons").contains("UI"))
 				return n;
@@ -137,8 +139,8 @@ public class Deploy {
 		return null;
 	}
 	
-	private static ArrayList<String> getNewInstancesPublicIp(Configuration config, String daemon, HashMap<Integer, NodeMetadata> nodes) {
-		ArrayList<Integer> nodeIds = new ArrayList<Integer>(nodes.keySet());
+	private static List<String> getNewInstancesPublicIp(Configuration config, String daemon, Map<Integer, NodeMetadata> nodes) {
+		List<Integer> nodeIds = new ArrayList<Integer>(nodes.keySet());
 		Collections.sort(nodeIds);
 		
 		ArrayList<String> newNodes = new ArrayList<String>();
@@ -150,8 +152,8 @@ public class Deploy {
 		return newNodes;
 	}
 	
-	private static ArrayList<String> getNewInstancesPrivateIp(Configuration config, String daemon, HashMap<Integer, NodeMetadata> nodes) {
-		ArrayList<Integer> nodeIds = new ArrayList<Integer>(nodes.keySet());
+	private static List<String> getNewInstancesPrivateIp(Configuration config, String daemon, Map<Integer, NodeMetadata> nodes) {
+		List<Integer> nodeIds = new ArrayList<Integer>(nodes.keySet());
 		Collections.sort(nodeIds);
 		
 		ArrayList<String> newNodes = new ArrayList<String>();
@@ -166,7 +168,7 @@ public class Deploy {
 	private static HashMap<Integer, NodeMetadata> startNodesNow(Configuration config, ComputeService compute, String clustername) {	
 
 		// To maintain worker threads
-		ArrayList<LaunchNodeThread> workerThreads = new ArrayList<LaunchNodeThread>();
+		List<LaunchNodeThread> workerThreads = new ArrayList<LaunchNodeThread>();
 				
 		/**
 		 * Loop each unique set of daemons
@@ -174,7 +176,7 @@ public class Deploy {
 		for (Entry<ArrayList<String>, ArrayList<Integer>> daemonsToNodeIds : config.getDaemonsToNodeIds().entrySet()) {
 			
 			// Create instanceType -> List[nodeIds]
-			HashMap<String, ArrayList<Integer>> instanceTypeToNodeIdsToStart = new HashMap<String, ArrayList<Integer>>();
+			Map<String, ArrayList<Integer>> instanceTypeToNodeIdsToStart = new HashMap<String, ArrayList<Integer>>();
 			for (Integer nodeId : daemonsToNodeIds.getValue()) {
 				String curInstanceType = config.getNodeIdToInstanceType().get(nodeId);
 				if (!instanceTypeToNodeIdsToStart.containsKey(curInstanceType))

--- a/src/dk/kaspergsm/stormdeploy/commands/ScaleOutCluster.java
+++ b/src/dk/kaspergsm/stormdeploy/commands/ScaleOutCluster.java
@@ -36,7 +36,7 @@ public class ScaleOutCluster {
 		 * Parse current running nodes for cluster
 		 */
 		ArrayList<NodeMetadata> existingZookeeper = new ArrayList<NodeMetadata>();
-		ArrayList<NodeMetadata> existingWorkers = new ArrayList<NodeMetadata>();
+		List<NodeMetadata> existingWorkers = new ArrayList<NodeMetadata>();
 		ArrayList<NodeMetadata> existingDRPC = new ArrayList<NodeMetadata>();
 		NodeMetadata nimbus = null, ui = null;
 		String image = null, region = null;
@@ -110,8 +110,8 @@ public class ScaleOutCluster {
 		System.exit(0);
 	}
 	
-	private static List<String> getInstancesPrivateIp(ArrayList<NodeMetadata> nodes) {
-		ArrayList<String> newNodes = new ArrayList<String>();
+	private static List<String> getInstancesPrivateIp(List<NodeMetadata> nodes) {
+		List<String> newNodes = new ArrayList<String>();
 		for (NodeMetadata n : nodes)
 			newNodes.add(n.getPrivateAddresses().iterator().next());
 		return newNodes;

--- a/src/dk/kaspergsm/stormdeploy/configurations/AWSCredentials.java
+++ b/src/dk/kaspergsm/stormdeploy/configurations/AWSCredentials.java
@@ -4,6 +4,7 @@ import static org.jclouds.scriptbuilder.domain.Statements.exec;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 import org.jclouds.scriptbuilder.domain.Statement;
 
@@ -11,7 +12,7 @@ public class AWSCredentials {
 
 	// This is lame.  Should really use IAM roles instead!!
 	public static Collection<Statement> configure(String region, String key, String secret) {
-		ArrayList<Statement> st = new ArrayList<Statement>();
+		List<Statement> st = new ArrayList<Statement>();
 		
 		// Add AWS credentials to env so AWS API can create credentials.
 		st.add(exec("echo \"export AWS_ACCESS_KEY_ID=" + key + "\" >> ~/.bashrc"));

--- a/src/dk/kaspergsm/stormdeploy/configurations/EC2Tools.java
+++ b/src/dk/kaspergsm/stormdeploy/configurations/EC2Tools.java
@@ -18,7 +18,7 @@ public class EC2Tools {
 	private static Logger log = LoggerFactory.getLogger(EC2Tools.class);
 	
 	public static List<Statement> install(PACKAGE_MANAGER pm) {
-		ArrayList<Statement> st = new ArrayList<Statement>();
+		List<Statement> st = new ArrayList<Statement>();
 		if (pm == PACKAGE_MANAGER.APT) {
 			st.add(exec("apt-get install ec2-api-tools"));
 			return st;
@@ -32,7 +32,7 @@ public class EC2Tools {
 	 * Returns commands to configure credentials
 	 */
 	public static List<Statement> configure(String certPath, String privPath, String region, String jobname) {
-		ArrayList<Statement> st = new ArrayList<Statement>();
+		List<Statement> st = new ArrayList<Statement>();
 		
 		// Write credentials
 		st.add(exec("mkdir ~/.ec2"));

--- a/src/dk/kaspergsm/stormdeploy/configurations/Ganglia.java
+++ b/src/dk/kaspergsm/stormdeploy/configurations/Ganglia.java
@@ -17,7 +17,7 @@ public class Ganglia {
 	 * Install Ganglia
 	 */
 	public static List<Statement> install() {
-		ArrayList<Statement> st = new ArrayList<Statement>();
+		List<Statement> st = new ArrayList<Statement>();
 		
 		// Install monitoring base
 		st.add(exec("apt-get install -y ganglia-monitor gmetad rrdtool librrds-perl librrd-dev"));
@@ -36,7 +36,7 @@ public class Ganglia {
 	 * Configure Ganglia
 	 */
 	public static List<Statement> configure(String clustername, String uiHostname) {
-		ArrayList<Statement> st = new ArrayList<Statement>();
+		List<Statement> st = new ArrayList<Statement>();
 		
 		// Strip top of configurationfile
 		st.add(exec("sed \'1,/Each metrics module that is referenced/d\' /etc/ganglia/gmond.conf > /etc/ganglia/stripped_gmond.conf"));
@@ -69,7 +69,7 @@ public class Ganglia {
 	 * Start daemons
 	 */
 	public static List<Statement> start() {
-		ArrayList<Statement> st = new ArrayList<Statement>();
+		List<Statement> st = new ArrayList<Statement>();
 		
 		// In case node is containing UI, it should enable module_rewrite for apache2
 		st.add(Tools.execOnUI("a2enmod rewrite"));

--- a/src/dk/kaspergsm/stormdeploy/configurations/S3CMD.java
+++ b/src/dk/kaspergsm/stormdeploy/configurations/S3CMD.java
@@ -20,7 +20,7 @@ public class S3CMD {
 	private static Logger log = LoggerFactory.getLogger(S3CMD.class);
 	
 	public static List<Statement> install(PACKAGE_MANAGER pm) {
-		ArrayList<Statement> st = new ArrayList<Statement>();
+		List<Statement> st = new ArrayList<Statement>();
 		if (pm == PACKAGE_MANAGER.APT) {
 			st.add(exec("wget -O- -q http://s3tools.org/repo/deb-all/stable/s3tools.key | apt-key add -"));
 			st.add(exec("wget -O/etc/apt/sources.list.d/s3tools.list http://s3tools.org/repo/deb-all/stable/s3tools.list"));
@@ -39,7 +39,7 @@ public class S3CMD {
 	 * The approach taken here, is to write a default version.
 	 */
 	public static List<Statement> configure(String identity, String credential) {
-		ArrayList<Statement> st = new ArrayList<Statement>();
+		List<Statement> st = new ArrayList<Statement>();
 		st.add(exec("cd ~"));
 		st.add(exec("rm .s3cfg"));
 		st.add(exec("touch .s3cfg"));

--- a/src/dk/kaspergsm/stormdeploy/configurations/Storm.java
+++ b/src/dk/kaspergsm/stormdeploy/configurations/Storm.java
@@ -28,7 +28,7 @@ public class Storm {
 	 * Write storm/conf/storm.yaml (basic settings only)
 	 */
 	public static List<Statement> configure(String hostname, List<String> zkNodesHostname, List<String> drpcHostname, String userName) {
-		ArrayList<Statement> st = new ArrayList<Statement>();
+		List<Statement> st = new ArrayList<Statement>();
 		st.add(exec("cd ~/storm/conf/"));
 		st.add(exec("touch storm.yaml"));
 		
@@ -65,7 +65,7 @@ public class Storm {
 	 * Uses Monitor to restart daemon, if it stops
 	 */
 	public static List<Statement> startNimbusDaemonSupervision(String username) {
-		ArrayList<Statement> st = new ArrayList<Statement>();
+		List<Statement> st = new ArrayList<Statement>();
 		st.add(exec("cd ~"));
 		st.add(exec("su -c 'case $(head -n 1 ~/daemons) in *MASTER*) java -cp \"sda/storm-deploy-alternative.jar\" dk.kaspergsm.stormdeploy.image.ProcessMonitor backtype.storm.daemon.nimbus storm/bin/storm nimbus ;; esac &' - " + username));
 		return st;
@@ -75,7 +75,7 @@ public class Storm {
 	 * Uses Monitor to restart daemon, if it stops
 	 */
 	public static List<Statement> startSupervisorDaemonSupervision(String username) {
-		ArrayList<Statement> st = new ArrayList<Statement>();
+		List<Statement> st = new ArrayList<Statement>();
 		st.add(exec("cd ~"));
 		st.add(exec("su -c 'case $(head -n 1 ~/daemons) in *WORKER*) java -cp \"sda/storm-deploy-alternative.jar\" dk.kaspergsm.stormdeploy.image.ProcessMonitor backtype.storm.daemon.supervisor storm/bin/storm supervisor ;; esac &' - " + username));
 		return st;
@@ -85,7 +85,7 @@ public class Storm {
 	 * Uses Monitor to restart daemon, if it stops
 	 */
 	public static List<Statement> startUIDaemonSupervision(String username) {
-		ArrayList<Statement> st = new ArrayList<Statement>();
+		List<Statement> st = new ArrayList<Statement>();
 		st.add(exec("cd ~"));
 		st.add(exec("su -c 'case $(head -n 1 ~/daemons) in *UI*) java -cp \"sda/storm-deploy-alternative.jar\" dk.kaspergsm.stormdeploy.image.ProcessMonitor backtype.storm.ui.core storm/bin/storm ui ;; esac &' - " + username));
 		return st;
@@ -95,7 +95,7 @@ public class Storm {
 	 * Uses Monitor to restart daemon, if it stops
 	 */
 	public static List<Statement> startDRPCDaemonSupervision(String username) {
-		ArrayList<Statement> st = new ArrayList<Statement>();
+		List<Statement> st = new ArrayList<Statement>();
 		st.add(exec("cd ~"));
 		st.add(exec("su -c 'case $(head -n 1 ~/daemons) in *DRPC*) java -cp \"sda/storm-deploy-alternative.jar\" dk.kaspergsm.stormdeploy.image.ProcessMonitor backtype.storm.daemon.drpc storm/bin/storm drpc ;; esac &' - " + username));
 		return st;
@@ -105,7 +105,7 @@ public class Storm {
      * Uses Monitor to restart daemon, if it stops
      */
 	public static List<Statement> startLogViewerDaemonSupervision(String username) {
-		ArrayList<Statement> st = new ArrayList<Statement>();
+		List<Statement> st = new ArrayList<Statement>();
 		st.add(exec("cd ~"));
 		st.add(exec("su -c 'case $(head -n 1 ~/daemons) in *LOGVIEWER*) java -cp \"sda/storm-deploy-alternative.jar\" dk.kaspergsm.stormdeploy.image.ProcessMonitor backtype.storm.daemon.logviewer storm/bin/storm logviewer ;; esac &' - " + username));
 		return st;

--- a/src/dk/kaspergsm/stormdeploy/configurations/StormDeployAlternative.java
+++ b/src/dk/kaspergsm/stormdeploy/configurations/StormDeployAlternative.java
@@ -24,13 +24,13 @@ public class StormDeployAlternative {
 	 * 	Requires tools.jar from active jvm is on path. Is automatically searched and found if it exists in /usr/lib/jvm
 	 */
 	public static List<Statement> runMemoryMonitor(String username) {
-		ArrayList<Statement> st = new ArrayList<Statement>();
+		List<Statement> st = new ArrayList<Statement>();
 		st.add(exec("su -c 'java -cp \"/home/"+username+"/sda/storm-deploy-alternative.jar:$( find `ls -d /usr/lib/jvm/* | sort -k1 -r` -name tools.jar | head -1 )\" dk.kaspergsm.stormdeploy.image.MemoryMonitor &' - " + username));
 		return st;
 	}
 	
 	public static List<Statement> writeConfigurationFiles(String localConfigurationFile, String localCredentialFile) {	
-		ArrayList<Statement> st = new ArrayList<Statement>();
+		List<Statement> st = new ArrayList<Statement>();
 		st.add(exec("mkdir ~/sda/conf"));
 		st.addAll(Tools.echoFile(localConfigurationFile, "~/sda/conf/configuration.yaml"));
 		st.addAll(Tools.echoFile(localCredentialFile, "~/sda/conf/credential.yaml"));
@@ -38,7 +38,7 @@ public class StormDeployAlternative {
 	}
 	
 	public static List<Statement> writeLocalSSHKeys(String sshKeyName) {
-		ArrayList<Statement> st = new ArrayList<Statement>();
+		List<Statement> st = new ArrayList<Statement>();
 		st.add(exec("mkdir ~/.ssh/"));
 		st.addAll(Tools.echoFile(Tools.getHomeDir() + ".ssh" + File.separator + sshKeyName, "~/.ssh/id_rsa"));
 		st.addAll(Tools.echoFile(Tools.getHomeDir() + ".ssh" + File.separator + sshKeyName + ".pub", "~/.ssh/id_rsa.pub"));

--- a/src/dk/kaspergsm/stormdeploy/configurations/SystemTools.java
+++ b/src/dk/kaspergsm/stormdeploy/configurations/SystemTools.java
@@ -20,7 +20,7 @@ public class SystemTools {
 	private static Logger log = LoggerFactory.getLogger(SystemTools.class);
 	
 	public static List<Statement> init(PACKAGE_MANAGER pm) {
-		ArrayList<Statement> st = new ArrayList<Statement>();
+		List<Statement> st = new ArrayList<Statement>();
 		if (pm == PACKAGE_MANAGER.APT) {
 			
 			// Enable multiverse

--- a/src/dk/kaspergsm/stormdeploy/configurations/ZeroMQ.java
+++ b/src/dk/kaspergsm/stormdeploy/configurations/ZeroMQ.java
@@ -16,7 +16,7 @@ public class ZeroMQ {
 	private static String _condJzmq = "$(find /usr/* -name 'zmq.jar' | wc -l) -eq 0";
 	
 	public static List<Statement> download() {
-		ArrayList<Statement> st = new ArrayList<Statement>();
+		List<Statement> st = new ArrayList<Statement>();
 		st.add(exec(Tools.conditionalExec(_condZmq, "cd ~")));
 		st.add(exec(Tools.conditionalExec(_condZmq, "wget http://download.zeromq.org/zeromq-2.1.7.tar.gz")));
 		st.add(exec(Tools.conditionalExec(_condZmq, "tar -zxf zeromq-2.1.7.tar.gz")));
@@ -24,8 +24,8 @@ public class ZeroMQ {
 		return st;
 	}
 	
-	public static ArrayList<Statement> configure() {
-		ArrayList<Statement> st = new ArrayList<Statement>();
+	public static List<Statement> configure() {
+		List<Statement> st = new ArrayList<Statement>();
 		st.add(exec(Tools.conditionalExec(_condZmq, "cd zeromq-2.1.7")));
 		st.add(exec(Tools.conditionalExec(_condZmq, "./configure")));
 		st.add(exec(Tools.conditionalExec(_condZmq, "make")));

--- a/src/dk/kaspergsm/stormdeploy/configurations/Zookeeper.java
+++ b/src/dk/kaspergsm/stormdeploy/configurations/Zookeeper.java
@@ -18,7 +18,7 @@ public class Zookeeper {
 	}
 
 	public static List<Statement> configure(List<String> zkNodesHostnames) {
-		ArrayList<Statement> st = new ArrayList<Statement>();
+		List<Statement> st = new ArrayList<Statement>();
 		StringBuilder sb = new StringBuilder();
 		for (int i = 1; i <= zkNodesHostnames.size(); i++) {
 			sb.append("server.");
@@ -39,7 +39,7 @@ public class Zookeeper {
 	}
 	
 	public static List<Statement> writeZKMyIds(String username, Integer zkid) {
-		ArrayList<Statement> st = new ArrayList<Statement>();
+		List<Statement> st = new ArrayList<Statement>();
 		st.add(exec("mkdir -p /tmp/zktmp"));												// ensure folders exist
 		st.add(exec("chown " + username + " /tmp/zktmp"));
 		st.add(exec("echo " + zkid + " > /tmp/zktmp/myid"));								// write myid
@@ -50,7 +50,7 @@ public class Zookeeper {
 	 * Uses Monitor to restart daemon, if it stops
 	 */
 	public static List<Statement> startDaemonSupervision(String username) {
-		ArrayList<Statement> st = new ArrayList<Statement>();
+		List<Statement> st = new ArrayList<Statement>();
 		st.add(exec("cd ~"));
 		st.add(exec("su -c 'case $(head -n 1 ~/daemons) in *ZK*) java -cp \"sda/storm-deploy-alternative.jar\" dk.kaspergsm.stormdeploy.image.ProcessMonitor org.apache.zookeeper.server zookeeper/bin/zkServer.sh start ;; esac &' - " + username));
 		return st;

--- a/src/dk/kaspergsm/stormdeploy/image/MemoryMonitor.java
+++ b/src/dk/kaspergsm/stormdeploy/image/MemoryMonitor.java
@@ -8,6 +8,7 @@ import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import javax.management.remote.JMXConnector;
 import javax.management.remote.JMXConnectorFactory;
 import javax.management.remote.JMXServiceURL;
@@ -131,8 +132,8 @@ class MemoryMonitor {
 	}
 	
 	
-	private static ArrayList<String>  getAllJavaProcesses() {
-		ArrayList<String> javaProcesses = new ArrayList<String>();
+	private static List<String> getAllJavaProcesses() {
+		List<String> javaProcesses = new ArrayList<String>();
 		try {
 			ProcessBuilder pb = new ProcessBuilder(Arrays.asList("jps"));
 			Process process = pb.start();

--- a/src/dk/kaspergsm/stormdeploy/userprovided/Configuration.java
+++ b/src/dk/kaspergsm/stormdeploy/userprovided/Configuration.java
@@ -5,7 +5,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import dk.kaspergsm.stormdeploy.Tools;
@@ -19,9 +23,9 @@ public class Configuration {
 	private static Logger log = LoggerFactory.getLogger(Configuration.class);
 	HashMap<Integer, String> _nodeIdToInstanceTypeID = null;
 	private String _imageID = null, _locationID = null;
-	private ArrayList<String> _conf;
+	private List<String> _conf;
 	
-	private HashSet<String> _allConfigurationSettings = new HashSet<String>(Arrays.asList(
+	private Set<String> _allConfigurationSettings = new HashSet<String>(Arrays.asList(
 			"storm-version", 
 			"zk-version",
 			"image","image-username",
@@ -58,7 +62,7 @@ public class Configuration {
 	/**
 	 * Get exec (pre config)
 	 */
-	public ArrayList<String> getRemoteExecPreConfig() {
+	public List<String> getRemoteExecPreConfig() {
 		ArrayList<String> execPreConfig = new ArrayList<String>();
 		for (int i = 0; i < _conf.size(); i++) {
 			String key = _conf.get(i).substring(0, _conf.get(i).indexOf(" "));
@@ -73,7 +77,7 @@ public class Configuration {
 	/**
 	 * Get exec (post config)
 	 */
-	public ArrayList<String> getRemoteExecPostConfig() {
+	public List<String> getRemoteExecPostConfig() {
 		ArrayList<String> execPostConfig = new ArrayList<String>();
 		for (int i = 0; i < _conf.size(); i++) {
 			String key = _conf.get(i).substring(0, _conf.get(i).indexOf(" "));
@@ -208,7 +212,7 @@ public class Configuration {
 	/**
 	 * Get map{node id, instanceType}
 	 */
-	public HashMap<Integer, String> getNodeIdToInstanceType() {
+	public Map<Integer, String> getNodeIdToInstanceType() {
 		if (_nodeIdToInstanceTypeID != null) {
 			return _nodeIdToInstanceTypeID;
 		}
@@ -229,7 +233,7 @@ public class Configuration {
 	/**
 	 * Get map{node id, zkid}
 	 */
-	public HashMap<Integer, Integer> getNodeIdToZkId() {
+	public Map<Integer, Integer> getNodeIdToZkId() {
 		int zkid = 1;
 		HashMap<Integer, Integer> nodeIdToZkId = new HashMap<Integer, Integer>();
 		for (int nodeId = 0; nodeId < _conf.size(); nodeId++) {
@@ -247,8 +251,8 @@ public class Configuration {
 	/**
 	 * Get map{arr[daemons], arr[node ids]}
 	 */
-	public HashMap<ArrayList<String>, ArrayList<Integer>> getDaemonsToNodeIds() {
-		HashMap<String, ArrayList<Integer>> deamonsToNodeIds = new HashMap<String, ArrayList<Integer>>();
+	public Map<ArrayList<String>, ArrayList<Integer>> getDaemonsToNodeIds() {
+		Map<String, ArrayList<Integer>> deamonsToNodeIds = new HashMap<String, ArrayList<Integer>>();
 		for (int i = 0; i < _conf.size(); i++) {
 			if (_allConfigurationSettings.contains(_conf.get(i).substring(0, _conf.get(i).indexOf(" "))))
 				continue;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1319 - “Declarations should use Java collection interfaces such as "List" rather than specific implementation classes such as "LinkedList" ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1319
Please let me know if you have any questions.
Ayman Abdelghany.