### PR TITLE
 Utility classes should not have public constructors

### DIFF
--- a/src/dk/kaspergsm/stormdeploy/configurations/EC2Tools.java
+++ b/src/dk/kaspergsm/stormdeploy/configurations/EC2Tools.java
@@ -16,7 +16,10 @@ import dk.kaspergsm.stormdeploy.configurations.SystemTools.PACKAGE_MANAGER;
  */
 public class EC2Tools {
 	private static Logger log = LoggerFactory.getLogger(EC2Tools.class);
-	
+
+	private EC2Tools() {
+	}
+
 	public static List<Statement> install(PACKAGE_MANAGER pm) {
 		ArrayList<Statement> st = new ArrayList<Statement>();
 		if (pm == PACKAGE_MANAGER.APT) {

--- a/src/dk/kaspergsm/stormdeploy/configurations/NodeConfiguration.java
+++ b/src/dk/kaspergsm/stormdeploy/configurations/NodeConfiguration.java
@@ -13,7 +13,10 @@ import dk.kaspergsm.stormdeploy.userprovided.Credential;
  * @author Kasper Grud Skat Madsen
  */
 public class NodeConfiguration {
-	
+
+	private NodeConfiguration() {
+	}
+
 	public static List<Statement> getCommands(String clustername, Credential credentials, Configuration config, List<String> zookeeperHostnames, List<String> drpcHostnames, String nimbusHostname, String uiHostname) {
 		List<Statement> commands = new ArrayList<Statement>();
 		

--- a/src/dk/kaspergsm/stormdeploy/configurations/S3CMD.java
+++ b/src/dk/kaspergsm/stormdeploy/configurations/S3CMD.java
@@ -18,7 +18,10 @@ import dk.kaspergsm.stormdeploy.configurations.SystemTools.PACKAGE_MANAGER;
 public class S3CMD {
 	private static Random r = new Random();
 	private static Logger log = LoggerFactory.getLogger(S3CMD.class);
-	
+
+	private S3CMD() {
+	}
+
 	public static List<Statement> install(PACKAGE_MANAGER pm) {
 		ArrayList<Statement> st = new ArrayList<Statement>();
 		if (pm == PACKAGE_MANAGER.APT) {

--- a/src/dk/kaspergsm/stormdeploy/configurations/SystemTools.java
+++ b/src/dk/kaspergsm/stormdeploy/configurations/SystemTools.java
@@ -16,6 +16,9 @@ import org.slf4j.LoggerFactory;
  * @author Kasper Grud Skat Madsen
  */
 public class SystemTools {
+	private SystemTools() {
+	}
+
 	public enum PACKAGE_MANAGER {APT};	
 	private static Logger log = LoggerFactory.getLogger(SystemTools.class);
 	

--- a/src/dk/kaspergsm/stormdeploy/configurations/ZeroMQ.java
+++ b/src/dk/kaspergsm/stormdeploy/configurations/ZeroMQ.java
@@ -14,7 +14,10 @@ import dk.kaspergsm.stormdeploy.Tools;
 public class ZeroMQ {
 	private static String _condZmq = "$(find /usr/* -name 'libzmq.a' | wc -l) -eq 0";
 	private static String _condJzmq = "$(find /usr/* -name 'zmq.jar' | wc -l) -eq 0";
-	
+
+	private ZeroMQ() {
+	}
+
 	public static List<Statement> download() {
 		ArrayList<Statement> st = new ArrayList<Statement>();
 		st.add(exec(Tools.conditionalExec(_condZmq, "cd ~")));

--- a/src/dk/kaspergsm/stormdeploy/configurations/Zookeeper.java
+++ b/src/dk/kaspergsm/stormdeploy/configurations/Zookeeper.java
@@ -13,6 +13,9 @@ import dk.kaspergsm.stormdeploy.Tools;
  */
 public class Zookeeper {
 
+	private Zookeeper() {
+	}
+
 	public static List<Statement> download(String zookeeperRemoteLocation) {
 		return Tools.download("~/", zookeeperRemoteLocation, true, true, "zookeeper");
 	}

--- a/src/dk/kaspergsm/stormdeploy/image/MemoryMonitor.java
+++ b/src/dk/kaspergsm/stormdeploy/image/MemoryMonitor.java
@@ -27,7 +27,10 @@ import com.sun.tools.attach.VirtualMachine;
  */
 class MemoryMonitor {
 	private static Logger log = LoggerFactory.getLogger(MemoryMonitor.class);
-	
+
+	private MemoryMonitor() {
+	}
+
 	public static void main(String[] args) throws IOException {
 		log.info("Initialized MemoryMonitor");
 		log.info("Software for helping Java proceses share memory");

--- a/src/dk/kaspergsm/stormdeploy/image/ProcessMonitor.java
+++ b/src/dk/kaspergsm/stormdeploy/image/ProcessMonitor.java
@@ -20,7 +20,10 @@ public class ProcessMonitor {
 	private static String[] _toExec;
 	private static String _process;
 	private static Timer t;
-	
+
+	private ProcessMonitor() {
+	}
+
 	public static void main(String[] args) {
 		// Expected args
 		// 1. Process id to check


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “Utility classes should not have public constructors ”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.