### PR TITLE
Fixing code quality issues: squid:S1854 - squid:S1858

### DIFF
--- a/src/dk/kaspergsm/stormdeploy/LaunchNodeThread.java
+++ b/src/dk/kaspergsm/stormdeploy/LaunchNodeThread.java
@@ -67,7 +67,7 @@ public class LaunchNodeThread extends Thread {
 		// Create initScript
 		_initScript = new ArrayList<Statement>();
 		_initScript.add(exec("echo \"" + daemons.toString() + "\" > ~/daemons"));
-		_initScript.add(exec("echo \"" + instanceType.toString() + "\" > ~/.instance-type"));
+		_initScript.add(exec("echo \"" + instanceType + "\" > ~/.instance-type"));
 		if (zkMyId != null)
 			_initScript.addAll(Zookeeper.writeZKMyIds(_username, zkMyId));
 

--- a/src/dk/kaspergsm/stormdeploy/Tools.java
+++ b/src/dk/kaspergsm/stormdeploy/Tools.java
@@ -161,7 +161,7 @@ public class Tools {
 		try {
 			BufferedReader reader = new BufferedReader(new FileReader(filePath));
 			char[] buf = new char[1024];
-			int numRead = 0;
+			int numRead;
 			while ((numRead = reader.read(buf)) != -1) {
 				String readData = String.valueOf(buf, 0, numRead);
 				fileData.append(readData);

--- a/src/dk/kaspergsm/stormdeploy/commands/ScaleOutCluster.java
+++ b/src/dk/kaspergsm/stormdeploy/commands/ScaleOutCluster.java
@@ -124,7 +124,7 @@ public class ScaleOutCluster {
 			// Create initScript
 			ArrayList<Statement> initScript = new ArrayList<Statement>();
 			initScript.add(exec("echo WORKER > ~/daemons"));
-			initScript.add(exec("echo \"" + instanceType.toString() + "\" > ~/.instance-type"));
+			initScript.add(exec("echo \"" + instanceType + "\" > ~/.instance-type"));
 			initScript.addAll(commands);
 			
 			log.info("Starting " + numInstances + " instance(s) of type " + instanceType);

--- a/src/dk/kaspergsm/stormdeploy/image/ProcessMonitor.java
+++ b/src/dk/kaspergsm/stormdeploy/image/ProcessMonitor.java
@@ -59,7 +59,7 @@ public class ProcessMonitor {
         BufferedReader i = new BufferedReader(new InputStreamReader(p.getInputStream()));
         
         // read the output from the command
-        String s = null;
+        String s;
         while ((s = i.readLine()) != null) {
         	if (s.contains(_process) && !s.contains("storm-deploy-alternative.jar")) // filter the monitoring process
         		return true;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1854 - “ Dead stores should be removed ”.
squid:S1858 - “"toString()" should never be called on a String object”.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1854
https://dev.eclipse.org/sonar/rules/show/squid:S1858
Please let me know if you have any questions.
Ayman Abdelghany.