### PR TITLE
Configurable Install Directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ conf/credential.yaml
 dependency-reduced-pom.xml
 memory-monitor.log
 /bin/
+.idea
+*.iml

--- a/README.markdown
+++ b/README.markdown
@@ -30,6 +30,7 @@ mycluster:
     - remote-exec-preconfig {cd ~, echo hey > hey.txt}
     - remote-exec-postconfig {}
     - ssh-key-name "mySSHKeyName"           # Optional. defaults to "id_rsa"
+    - install-dir "/mnt"
 ```
 + MASTER is the Storm Nimbus daemon
 + WORKER is the Storm Supervisor daemon

--- a/conf/configuration_example.yaml
+++ b/conf/configuration_example.yaml
@@ -15,3 +15,4 @@ ectwo:
     - remote-exec-preconfig {cd ~, echo hey > hey.txt}
     - remote-exec-postconfig {}
     - ssh-key-name "mySSHKeyName"           # Optional. defaults to "id_rsa"
+    - install-dir "/mnt/"

--- a/src/dk/kaspergsm/stormdeploy/StormDeployAlternative.java
+++ b/src/dk/kaspergsm/stormdeploy/StormDeployAlternative.java
@@ -36,6 +36,8 @@ public class StormDeployAlternative {
 		String operation = args[0];
 		String clustername = args[1].toLowerCase();
 		Configuration config = Configuration.fromYamlFile(new File(Tools.getWorkDir() + "conf" + File.separator + "configuration.yaml"), clustername);
+		// Set install dir here so that we don’t have to keep passing around Configuration.
+		System.setProperty("install.dir", config.getInstallDir());
 		Credential credentials = new Credential(new File(Tools.getWorkDir() + "conf" + File.separator + "credential.yaml"));
 
 

--- a/src/dk/kaspergsm/stormdeploy/Tools.java
+++ b/src/dk/kaspergsm/stormdeploy/Tools.java
@@ -253,7 +253,7 @@ public class Tools {
 	}
 	
 	public static Statement execOnUI(String cmd) {
-		return exec("case $(head -n 1 ~/daemons) in *UI*) " + cmd + " ;; esac");
+		return exec("case $(head -n 1 " + System.getProperty("install.dir") + "daemons) in *UI*) " + cmd + " ;; esac");
 	}
 	
 	public static String getInstanceIp(NodeMetadata node) {

--- a/src/dk/kaspergsm/stormdeploy/commands/ScaleOutCluster.java
+++ b/src/dk/kaspergsm/stormdeploy/commands/ScaleOutCluster.java
@@ -122,9 +122,15 @@ public class ScaleOutCluster {
 		try {
 			
 			// Create initScript
+			String installDir = System.getProperty("install.dir");
 			ArrayList<Statement> initScript = new ArrayList<Statement>();
-			initScript.add(exec("echo WORKER > ~/daemons"));
-			initScript.add(exec("echo \"" + instanceType + "\" > ~/.instance-type"));
+			initScript.add(exec("mkdir -p "+ installDir));
+			if (!"~/".equals(installDir)) {
+				initScript.add(exec("chown " + config.getImageUsername() + " " + installDir));
+			}
+			initScript.add(exec("echo WORKER > " + installDir + "daemons"));
+			initScript.add(exec("echo WORKER > " + installDir + "daemons"));
+			initScript.add(exec("echo \"" + instanceType + "\" > "+ installDir +".instance-type"));
 			initScript.addAll(commands);
 			
 			log.info("Starting " + numInstances + " instance(s) of type " + instanceType);

--- a/src/dk/kaspergsm/stormdeploy/configurations/NodeConfiguration.java
+++ b/src/dk/kaspergsm/stormdeploy/configurations/NodeConfiguration.java
@@ -45,7 +45,7 @@ public class NodeConfiguration {
 		commands.addAll(ZeroMQ.configure());
 		
 		// Download and configure storm-deploy-alternative (before anything with supervision is started)
-		commands.addAll(StormDeployAlternative.download());
+		commands.addAll(StormDeployAlternative.download(config.getImageUsername()));
 		commands.addAll(StormDeployAlternative.writeConfigurationFiles(Tools.getWorkDir() + "conf" + File.separator + "configuration.yaml", Tools.getWorkDir() + "conf" + File.separator + "credential.yaml"));
 		commands.addAll(StormDeployAlternative.writeLocalSSHKeys(config.getSSHKeyName()));
 		

--- a/src/dk/kaspergsm/stormdeploy/configurations/Storm.java
+++ b/src/dk/kaspergsm/stormdeploy/configurations/Storm.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import dk.kaspergsm.stormdeploy.userprovided.Configuration;
 import org.jclouds.scriptbuilder.domain.Statement;
 
 import dk.kaspergsm.stormdeploy.Tools;
@@ -21,7 +22,8 @@ import dk.kaspergsm.stormdeploy.Tools;
 public class Storm {
 
 	public static List<Statement> download(String stormRemoteLocation) {
-        return Tools.download("~/", stormRemoteLocation, true, true, "storm");
+
+        return Tools.download(System.getProperty("install.dir"), stormRemoteLocation, true, true, "storm");
 	}
 	
 	/**
@@ -29,7 +31,8 @@ public class Storm {
 	 */
 	public static List<Statement> configure(String hostname, List<String> zkNodesHostname, List<String> drpcHostname, String userName) {
 		List<Statement> st = new ArrayList<Statement>();
-		st.add(exec("cd ~/storm/conf/"));
+		String installDir = System.getProperty("install.dir");
+		st.add(exec("cd " + installDir + "storm/conf/"));
 		st.add(exec("touch storm.yaml"));
 		
 		// Add nimbus.host
@@ -49,14 +52,14 @@ public class Storm {
 
 		// Add supervisor metadata
 		st.add(exec("echo supervisor.scheduler.meta: >> storm.yaml"));
-		st.add(exec("instancetype=$(cat ~/.instance-type)"));
+		st.add(exec("instancetype=$(cat " + installDir + ".instance-type)"));
 		st.add(exec("echo \"  instancetype: \\\"$instancetype\\\"\" >> storm.yaml"));
 		
 		// Change owner of storm directory
-		st.add(exec("chown -R " + userName + ":" + userName + " ~/storm"));
+		st.add(exec("chown -R " + userName + ":" + userName + " " + installDir + "storm"));
 		
 		// Add storm to execution PATH
-		st.add(exec("echo \"export PATH=\\\"\\$HOME/storm/bin:\\$PATH\\\"\" >> ~/.bashrc"));
+		st.add(exec("echo \"export PATH=\\\"" + installDir + "storm/bin:\\$PATH\\\"\" >> ~/.bashrc"));
                 
 		return st;
 	}
@@ -65,9 +68,10 @@ public class Storm {
 	 * Uses Monitor to restart daemon, if it stops
 	 */
 	public static List<Statement> startNimbusDaemonSupervision(String username) {
+		String installDir = System.getProperty("install.dir");
 		List<Statement> st = new ArrayList<Statement>();
-		st.add(exec("cd ~"));
-		st.add(exec("su -c 'case $(head -n 1 ~/daemons) in *MASTER*) java -cp \"sda/storm-deploy-alternative.jar\" dk.kaspergsm.stormdeploy.image.ProcessMonitor backtype.storm.daemon.nimbus storm/bin/storm nimbus ;; esac &' - " + username));
+		st.add(goToInstallDir());
+		st.add(exec("su -c 'case $(head -n 1 " + installDir + "daemons) in *MASTER*) java -cp \"" + installDir + "sda/storm-deploy-alternative.jar\" dk.kaspergsm.stormdeploy.image.ProcessMonitor backtype.storm.daemon.nimbus " + installDir + "storm/bin/storm nimbus ;; esac &' - " + username));
 		return st;
 	}
 	
@@ -75,9 +79,10 @@ public class Storm {
 	 * Uses Monitor to restart daemon, if it stops
 	 */
 	public static List<Statement> startSupervisorDaemonSupervision(String username) {
+		String installDir = System.getProperty("install.dir");
 		List<Statement> st = new ArrayList<Statement>();
-		st.add(exec("cd ~"));
-		st.add(exec("su -c 'case $(head -n 1 ~/daemons) in *WORKER*) java -cp \"sda/storm-deploy-alternative.jar\" dk.kaspergsm.stormdeploy.image.ProcessMonitor backtype.storm.daemon.supervisor storm/bin/storm supervisor ;; esac &' - " + username));
+		st.add(goToInstallDir());
+		st.add(exec("su -c 'case $(head -n 1 " + installDir + "daemons) in *WORKER*) java -cp \"" + installDir + "sda/storm-deploy-alternative.jar\" dk.kaspergsm.stormdeploy.image.ProcessMonitor backtype.storm.daemon.supervisor " + installDir + "storm/bin/storm supervisor ;; esac &' - " + username));
 		return st;
 	}
 	
@@ -85,9 +90,10 @@ public class Storm {
 	 * Uses Monitor to restart daemon, if it stops
 	 */
 	public static List<Statement> startUIDaemonSupervision(String username) {
+		String installDir = System.getProperty("install.dir");
 		List<Statement> st = new ArrayList<Statement>();
-		st.add(exec("cd ~"));
-		st.add(exec("su -c 'case $(head -n 1 ~/daemons) in *UI*) java -cp \"sda/storm-deploy-alternative.jar\" dk.kaspergsm.stormdeploy.image.ProcessMonitor backtype.storm.ui.core storm/bin/storm ui ;; esac &' - " + username));
+		st.add(goToInstallDir());
+		st.add(exec("su -c 'case $(head -n 1 " + installDir + "daemons) in *UI*) java -cp \"" + installDir + "sda/storm-deploy-alternative.jar\" dk.kaspergsm.stormdeploy.image.ProcessMonitor backtype.storm.ui.core " + installDir + "storm/bin/storm ui ;; esac &' - " + username));
 		return st;
 	}
 	
@@ -95,9 +101,10 @@ public class Storm {
 	 * Uses Monitor to restart daemon, if it stops
 	 */
 	public static List<Statement> startDRPCDaemonSupervision(String username) {
+		String installDir = System.getProperty("install.dir");
 		List<Statement> st = new ArrayList<Statement>();
-		st.add(exec("cd ~"));
-		st.add(exec("su -c 'case $(head -n 1 ~/daemons) in *DRPC*) java -cp \"sda/storm-deploy-alternative.jar\" dk.kaspergsm.stormdeploy.image.ProcessMonitor backtype.storm.daemon.drpc storm/bin/storm drpc ;; esac &' - " + username));
+		st.add(goToInstallDir());
+		st.add(exec("su -c 'case $(head -n 1 " + installDir + "daemons) in *DRPC*) java -cp \"" + installDir + "sda/storm-deploy-alternative.jar\" dk.kaspergsm.stormdeploy.image.ProcessMonitor backtype.storm.daemon.drpc " + installDir + "storm/bin/storm drpc ;; esac &' - " + username));
 		return st;
 	}
 	
@@ -105,9 +112,10 @@ public class Storm {
      * Uses Monitor to restart daemon, if it stops
      */
 	public static List<Statement> startLogViewerDaemonSupervision(String username) {
+		String installDir = System.getProperty("install.dir");
 		List<Statement> st = new ArrayList<Statement>();
-		st.add(exec("cd ~"));
-		st.add(exec("su -c 'case $(head -n 1 ~/daemons) in *LOGVIEWER*) java -cp \"sda/storm-deploy-alternative.jar\" dk.kaspergsm.stormdeploy.image.ProcessMonitor backtype.storm.daemon.logviewer storm/bin/storm logviewer ;; esac &' - " + username));
+		st.add(goToInstallDir());
+		st.add(exec("su -c 'case $(head -n 1 " + installDir + "daemons) in *LOGVIEWER*) java -cp \"" + installDir + "sda/storm-deploy-alternative.jar\" dk.kaspergsm.stormdeploy.image.ProcessMonitor backtype.storm.daemon.logviewer " + installDir + "storm/bin/storm logviewer ;; esac &' - " + username));
 		return st;
 	}
 	
@@ -150,5 +158,9 @@ public class Storm {
 		}
 		supervisorYaml.flush();
 		supervisorYaml.close();
+	}
+
+	private static Statement goToInstallDir(){
+		return exec("cd " + System.getProperty("install.dir"));
 	}
 }

--- a/src/dk/kaspergsm/stormdeploy/configurations/StormDeployAlternative.java
+++ b/src/dk/kaspergsm/stormdeploy/configurations/StormDeployAlternative.java
@@ -15,8 +15,15 @@ import dk.kaspergsm.stormdeploy.Tools;
  */
 public class StormDeployAlternative {
 
-	public static List<Statement> download() {
-		return Tools.download("~", "https://s3-eu-west-1.amazonaws.com/storm-deploy-alternative/sda.tar.gz", true, true);
+	public static List<Statement> download(String username) {
+		String installDir = System.getProperty("install.dir");
+		List<Statement> st = new ArrayList<Statement>();
+		st.add(exec("mkdir -p "+ installDir));
+		if (!"~/".equals(installDir)) {
+			st.add(exec("chown " + username + " " + installDir));
+		}
+		st.addAll(Tools.download(installDir, "https://s3-eu-west-1.amazonaws.com/storm-deploy-alternative/sda.tar.gz", true, true));
+		return st;
 	}
 	
 	/**
@@ -25,15 +32,16 @@ public class StormDeployAlternative {
 	 */
 	public static List<Statement> runMemoryMonitor(String username) {
 		List<Statement> st = new ArrayList<Statement>();
-		st.add(exec("su -c 'java -cp \"/home/"+username+"/sda/storm-deploy-alternative.jar:$( find `ls -d /usr/lib/jvm/* | sort -k1 -r` -name tools.jar | head -1 )\" dk.kaspergsm.stormdeploy.image.MemoryMonitor &' - " + username));
+		st.add(exec("su -c 'java -cp \"" + System.getProperty("install.dir") + "sda/storm-deploy-alternative.jar:$( find `ls -d /usr/lib/jvm/* | sort -k1 -r` -name tools.jar | head -1 )\" dk.kaspergsm.stormdeploy.image.MemoryMonitor &' - " + username));
 		return st;
 	}
 	
-	public static List<Statement> writeConfigurationFiles(String localConfigurationFile, String localCredentialFile) {	
+	public static List<Statement> writeConfigurationFiles(String localConfigurationFile, String localCredentialFile) {
+		String installDir = System.getProperty("install.dir");
 		List<Statement> st = new ArrayList<Statement>();
-		st.add(exec("mkdir ~/sda/conf"));
-		st.addAll(Tools.echoFile(localConfigurationFile, "~/sda/conf/configuration.yaml"));
-		st.addAll(Tools.echoFile(localCredentialFile, "~/sda/conf/credential.yaml"));
+		st.add(exec("mkdir " + installDir + "sda/conf"));
+		st.addAll(Tools.echoFile(localConfigurationFile, installDir + "sda/conf/configuration.yaml"));
+		st.addAll(Tools.echoFile(localCredentialFile, installDir + "sda/conf/credential.yaml"));
 		return st;
 	}
 	

--- a/src/dk/kaspergsm/stormdeploy/configurations/ZeroMQ.java
+++ b/src/dk/kaspergsm/stormdeploy/configurations/ZeroMQ.java
@@ -20,7 +20,7 @@ public class ZeroMQ {
 
 	public static List<Statement> download() {
 		List<Statement> st = new ArrayList<Statement>();
-		st.add(exec(Tools.conditionalExec(_condZmq, "cd ~")));
+		st.add(exec(Tools.conditionalExec(_condZmq, "cd " + System.getProperty("install.dir"))));
 		st.add(exec(Tools.conditionalExec(_condZmq, "wget http://download.zeromq.org/zeromq-2.1.7.tar.gz")));
 		st.add(exec(Tools.conditionalExec(_condZmq, "tar -zxf zeromq-2.1.7.tar.gz")));
 		st.add(exec(Tools.conditionalExec(_condZmq, "rm zeromq-2.1.7.tar.gz")));

--- a/src/dk/kaspergsm/stormdeploy/configurations/Zookeeper.java
+++ b/src/dk/kaspergsm/stormdeploy/configurations/Zookeeper.java
@@ -17,7 +17,7 @@ public class Zookeeper {
 	}
 
 	public static List<Statement> download(String zookeeperRemoteLocation) {
-		return Tools.download("~/", zookeeperRemoteLocation, true, true, "zookeeper");
+		return Tools.download(System.getProperty("install.dir"), zookeeperRemoteLocation, true, true, "zookeeper");
 	}
 
 	public static List<Statement> configure(List<String> zkNodesHostnames) {
@@ -32,7 +32,7 @@ public class Zookeeper {
 			if (i != zkNodesHostnames.size())
 				sb.append("\\n"); // escaped newline
 		}
-		st.add(exec("cd ~/zookeeper/conf/"));
+		st.add(exec("cd "+ System.getProperty("install.dir") +"zookeeper/conf/"));
 		st.add(exec("[ ! -e zoo.cfg ] && cp zoo_sample.cfg zoo.cfg && echo -e \"# the zookeeper ensemble\nserver.x\" >> zoo.cfg"));
 		st.add(exec("sed \"s|dataDir=.*|dataDir=/tmp/zktmp|\" -i \"zoo.cfg\""));	// set dataDir to /tmp/zktmp
 		st.add(exec("sed \"s/server.*/server.x/\" -i \"zoo.cfg\""));				// convert each serverline to server.x
@@ -54,8 +54,9 @@ public class Zookeeper {
 	 */
 	public static List<Statement> startDaemonSupervision(String username) {
 		List<Statement> st = new ArrayList<Statement>();
-		st.add(exec("cd ~"));
-		st.add(exec("su -c 'case $(head -n 1 ~/daemons) in *ZK*) java -cp \"sda/storm-deploy-alternative.jar\" dk.kaspergsm.stormdeploy.image.ProcessMonitor org.apache.zookeeper.server zookeeper/bin/zkServer.sh start ;; esac &' - " + username));
+		String installDir = System.getProperty("install.dir");
+		st.add(exec("cd " + installDir));
+		st.add(exec("su -c 'case $(head -n 1 " + installDir + "daemons) in *ZK*) java -cp \""+ installDir +"sda/storm-deploy-alternative.jar\" dk.kaspergsm.stormdeploy.image.ProcessMonitor org.apache.zookeeper.server "+ installDir +"zookeeper/bin/zkServer.sh start ;; esac &' - " + username));
 		return st;
 	}
 }

--- a/src/dk/kaspergsm/stormdeploy/userprovided/Configuration.java
+++ b/src/dk/kaspergsm/stormdeploy/userprovided/Configuration.java
@@ -35,7 +35,8 @@ public class Configuration {
 			"memory-monitor",
 			"remote-exec-preconfig",
 			"remote-exec-postconfig",
-			"ssh-key-name"));
+			"ssh-key-name",
+			"install-dir"));
 	
 	public static Configuration fromYamlFile(File f, String clustername) {
 		return new Configuration(Tools.readYamlConf(f), clustername);
@@ -181,6 +182,8 @@ public class Configuration {
 			return "https://s3-eu-west-1.amazonaws.com/storm-releases/apache-storm-0.9.5.tar.gz";
 		} else if (version.equals("0.10.0")) {
 			return "https://s3-eu-west-1.amazonaws.com/storm-releases/apache-storm-0.10.0.tar.gz";
+		} else if (version.equals("1.0.1")) {
+			return "https://s3-eu-west-1.amazonaws.com/storm-releases/apache-storm-1.0.1.tar.gz";
 		} else {
 			log.info("Storm version " + version + " not currently supported!");
 		}
@@ -199,6 +202,24 @@ public class Configuration {
 
 		return sshKeyName;
 	}
+
+	/**
+	 * Get install directory
+	 */
+	public String getInstallDir() {
+		String installDir = getRawConfigValue("install-dir");
+
+		// If no install-dir is specified, assume home directory
+		if (installDir == null) {
+			installDir = "~/";
+		}
+
+		if (!installDir.endsWith(File.separator)) {
+			installDir += File.separator;
+		}
+		return installDir;
+	}
+
 
 	private String getRawConfigValue(String k) {
 		for (int i = 0; i < _conf.size(); i++) {


### PR DESCRIPTION
In this commit, users can specify an install directory rather than having everything installed in ~/.

This is perfect for if you need to target a larger mounted disk for install rather than a user's home directory, which tends to be located on smaller disks.

One thing I'm not really happy with in this change is putting the "install.dir" as a System property to remove the need to pass Configuration around all the time.

Please see question on #34 

Fixes issue #34 