### PR TITLE
Fixes to make sda work with Storm 1.0.1

### DIFF
--- a/src/dk/kaspergsm/stormdeploy/configurations/NodeConfiguration.java
+++ b/src/dk/kaspergsm/stormdeploy/configurations/NodeConfiguration.java
@@ -80,11 +80,11 @@ public class NodeConfiguration {
 		 * Start daemons (only on correct nodes, and under supervision)
 		 */
 		commands.addAll(Zookeeper.startDaemonSupervision(config.getImageUsername()));
-		commands.addAll(Storm.startNimbusDaemonSupervision(config.getImageUsername()));
-		commands.addAll(Storm.startSupervisorDaemonSupervision(config.getImageUsername()));
-		commands.addAll(Storm.startUIDaemonSupervision(config.getImageUsername()));
-		commands.addAll(Storm.startDRPCDaemonSupervision(config.getImageUsername()));
-		commands.addAll(Storm.startLogViewerDaemonSupervision(config.getImageUsername()));
+		commands.addAll(Storm.startNimbusDaemonSupervision(config.getImageUsername(), config.getStormVersion()));
+		commands.addAll(Storm.startSupervisorDaemonSupervision(config.getImageUsername(), config.getStormVersion()));
+		commands.addAll(Storm.startUIDaemonSupervision(config.getImageUsername(), config.getStormVersion()));
+		commands.addAll(Storm.startDRPCDaemonSupervision(config.getImageUsername(), config.getStormVersion()));
+		commands.addAll(Storm.startLogViewerDaemonSupervision(config.getImageUsername(), config.getStormVersion()));
 		commands.addAll(Ganglia.start());
 		
 		/**

--- a/src/dk/kaspergsm/stormdeploy/configurations/NodeConfiguration.java
+++ b/src/dk/kaspergsm/stormdeploy/configurations/NodeConfiguration.java
@@ -66,7 +66,7 @@ public class NodeConfiguration {
 		commands.addAll(Zookeeper.configure(zookeeperHostnames));
 		
 		// Configure Storm (update configurationfiles)
-		commands.addAll(Storm.configure(nimbusHostname, zookeeperHostnames, drpcHostnames, config.getImageUsername()));
+		commands.addAll(Storm.configure(nimbusHostname, zookeeperHostnames, drpcHostnames, config.getImageUsername(), config.getStormVersion()));
 		
 		// Configure Ganglia
 		commands.addAll(Ganglia.configure(clustername, uiHostname));

--- a/src/dk/kaspergsm/stormdeploy/configurations/Storm.java
+++ b/src/dk/kaspergsm/stormdeploy/configurations/Storm.java
@@ -29,16 +29,19 @@ public class Storm {
 	/**
 	 * Write storm/conf/storm.yaml (basic settings only)
 	 */
-	public static List<Statement> configure(String hostname, List<String> zkNodesHostname, List<String> drpcHostname, String userName) {
+	public static List<Statement> configure(String hostname, List<String> zkNodesHostname, List<String> drpcHostname, String userName, String stormVersion) {
 		List<Statement> st = new ArrayList<Statement>();
 		String installDir = System.getProperty("install.dir");
 		st.add(exec("cd " + installDir + "storm/conf/"));
 		st.add(exec("touch storm.yaml"));
 		
 		// Add nimbus.host
-		//FIXME: This differs between storm versions! Need to check here
-		st.add(exec("echo nimbus.seeds: [\"" + hostname + "\"]git  >> storm.yaml"));
-		
+		if (stormVersion != null && stormVersion.startsWith("1")) {
+			st.add(exec("echo nimbus.seeds: [\"" + hostname + "\"]  >> storm.yaml"));
+		} else {
+			st.add(exec("echo nimbus.host: \"" + hostname + "\"  >> storm.yaml"));
+		}
+
 		// Add storm.zookeeper.servers
 		st.add(exec("echo storm.zookeeper.servers: >> storm.yaml"));
 		for (int i = 1; i <= zkNodesHostname.size(); i++)

--- a/src/dk/kaspergsm/stormdeploy/configurations/Storm.java
+++ b/src/dk/kaspergsm/stormdeploy/configurations/Storm.java
@@ -71,55 +71,55 @@ public class Storm {
 	/**
 	 * Uses Monitor to restart daemon, if it stops
 	 */
-	public static List<Statement> startNimbusDaemonSupervision(String username) {
+	public static List<Statement> startNimbusDaemonSupervision(String username, String stormVersion) {
 		String installDir = System.getProperty("install.dir");
 		List<Statement> st = new ArrayList<Statement>();
 		st.add(goToInstallDir());
-		st.add(exec("su -c 'case $(head -n 1 " + installDir + "daemons) in *MASTER*) java -cp \"" + installDir + "sda/storm-deploy-alternative.jar\" dk.kaspergsm.stormdeploy.image.ProcessMonitor org.apache.storm.daemon.nimbus " + installDir + "storm/bin/storm nimbus ;; esac &' - " + username));
+		st.add(exec("su -c 'case $(head -n 1 " + installDir + "daemons) in *MASTER*) java -cp \"" + installDir + "sda/storm-deploy-alternative.jar\" dk.kaspergsm.stormdeploy.image.ProcessMonitor "+ getStormPackageForVersion(stormVersion) +".storm.daemon.nimbus " + installDir + "storm/bin/storm nimbus ;; esac &' - " + username));
 		return st;
 	}
 	
 	/**
 	 * Uses Monitor to restart daemon, if it stops
 	 */
-	public static List<Statement> startSupervisorDaemonSupervision(String username) {
+	public static List<Statement> startSupervisorDaemonSupervision(String username, String stormVersion) {
 		String installDir = System.getProperty("install.dir");
 		List<Statement> st = new ArrayList<Statement>();
 		st.add(goToInstallDir());
-		st.add(exec("su -c 'case $(head -n 1 " + installDir + "daemons) in *WORKER*) java -cp \"" + installDir + "sda/storm-deploy-alternative.jar\" dk.kaspergsm.stormdeploy.image.ProcessMonitor org.apache.storm.daemon.supervisor " + installDir + "storm/bin/storm supervisor ;; esac &' - " + username));
+		st.add(exec("su -c 'case $(head -n 1 " + installDir + "daemons) in *WORKER*) java -cp \"" + installDir + "sda/storm-deploy-alternative.jar\" dk.kaspergsm.stormdeploy.image.ProcessMonitor "+ getStormPackageForVersion(stormVersion) +".storm.daemon.supervisor " + installDir + "storm/bin/storm supervisor ;; esac &' - " + username));
 		return st;
 	}
 	
 	/**
 	 * Uses Monitor to restart daemon, if it stops
 	 */
-	public static List<Statement> startUIDaemonSupervision(String username) {
+	public static List<Statement> startUIDaemonSupervision(String username, String stormVersion) {
 		String installDir = System.getProperty("install.dir");
 		List<Statement> st = new ArrayList<Statement>();
 		st.add(goToInstallDir());
-		st.add(exec("su -c 'case $(head -n 1 " + installDir + "daemons) in *UI*) java -cp \"" + installDir + "sda/storm-deploy-alternative.jar\" dk.kaspergsm.stormdeploy.image.ProcessMonitor org.apache.storm.ui.core " + installDir + "storm/bin/storm ui ;; esac &' - " + username));
+		st.add(exec("su -c 'case $(head -n 1 " + installDir + "daemons) in *UI*) java -cp \"" + installDir + "sda/storm-deploy-alternative.jar\" dk.kaspergsm.stormdeploy.image.ProcessMonitor "+ getStormPackageForVersion(stormVersion) +".storm.ui.core " + installDir + "storm/bin/storm ui ;; esac &' - " + username));
 		return st;
 	}
 	
 	/**
 	 * Uses Monitor to restart daemon, if it stops
 	 */
-	public static List<Statement> startDRPCDaemonSupervision(String username) {
+	public static List<Statement> startDRPCDaemonSupervision(String username, String stormVersion) {
 		String installDir = System.getProperty("install.dir");
 		List<Statement> st = new ArrayList<Statement>();
 		st.add(goToInstallDir());
-		st.add(exec("su -c 'case $(head -n 1 " + installDir + "daemons) in *DRPC*) java -cp \"" + installDir + "sda/storm-deploy-alternative.jar\" dk.kaspergsm.stormdeploy.image.ProcessMonitor org.apache.storm.daemon.drpc " + installDir + "storm/bin/storm drpc ;; esac &' - " + username));
+		st.add(exec("su -c 'case $(head -n 1 " + installDir + "daemons) in *DRPC*) java -cp \"" + installDir + "sda/storm-deploy-alternative.jar\" dk.kaspergsm.stormdeploy.image.ProcessMonitor "+ getStormPackageForVersion(stormVersion) +".storm.daemon.drpc " + installDir + "storm/bin/storm drpc ;; esac &' - " + username));
 		return st;
 	}
 	
     /**
      * Uses Monitor to restart daemon, if it stops
      */
-	public static List<Statement> startLogViewerDaemonSupervision(String username) {
+	public static List<Statement> startLogViewerDaemonSupervision(String username, String stormVersion) {
 		String installDir = System.getProperty("install.dir");
 		List<Statement> st = new ArrayList<Statement>();
 		st.add(goToInstallDir());
-		st.add(exec("su -c 'case $(head -n 1 " + installDir + "daemons) in *LOGVIEWER*) java -cp \"" + installDir + "sda/storm-deploy-alternative.jar\" dk.kaspergsm.stormdeploy.image.ProcessMonitor org.apache.storm.daemon.logviewer " + installDir + "storm/bin/storm logviewer ;; esac &' - " + username));
+		st.add(exec("su -c 'case $(head -n 1 " + installDir + "daemons) in *LOGVIEWER*) java -cp \"" + installDir + "sda/storm-deploy-alternative.jar\" dk.kaspergsm.stormdeploy.image.ProcessMonitor "+ getStormPackageForVersion(stormVersion) +".storm.daemon.logviewer " + installDir + "storm/bin/storm logviewer ;; esac &' - " + username));
 		return st;
 	}
 	
@@ -166,5 +166,13 @@ public class Storm {
 
 	private static Statement goToInstallDir(){
 		return exec("cd " + System.getProperty("install.dir"));
+	}
+
+	private static String getStormPackageForVersion(String stormVersion){
+		if (stormVersion != null && stormVersion.startsWith("1")) {
+			return "org.apache";
+		} else {
+			return "backtype";
+		}
 	}
 }

--- a/src/dk/kaspergsm/stormdeploy/configurations/Storm.java
+++ b/src/dk/kaspergsm/stormdeploy/configurations/Storm.java
@@ -36,7 +36,8 @@ public class Storm {
 		st.add(exec("touch storm.yaml"));
 		
 		// Add nimbus.host
-		st.add(exec("echo nimbus.host: \"" + hostname + "\" >> storm.yaml"));
+		//FIXME: This differs between storm versions! Need to check here
+		st.add(exec("echo nimbus.seeds: [\"" + hostname + "\"]git  >> storm.yaml"));
 		
 		// Add storm.zookeeper.servers
 		st.add(exec("echo storm.zookeeper.servers: >> storm.yaml"));
@@ -71,7 +72,7 @@ public class Storm {
 		String installDir = System.getProperty("install.dir");
 		List<Statement> st = new ArrayList<Statement>();
 		st.add(goToInstallDir());
-		st.add(exec("su -c 'case $(head -n 1 " + installDir + "daemons) in *MASTER*) java -cp \"" + installDir + "sda/storm-deploy-alternative.jar\" dk.kaspergsm.stormdeploy.image.ProcessMonitor backtype.storm.daemon.nimbus " + installDir + "storm/bin/storm nimbus ;; esac &' - " + username));
+		st.add(exec("su -c 'case $(head -n 1 " + installDir + "daemons) in *MASTER*) java -cp \"" + installDir + "sda/storm-deploy-alternative.jar\" dk.kaspergsm.stormdeploy.image.ProcessMonitor org.apache.storm.daemon.nimbus " + installDir + "storm/bin/storm nimbus ;; esac &' - " + username));
 		return st;
 	}
 	
@@ -82,7 +83,7 @@ public class Storm {
 		String installDir = System.getProperty("install.dir");
 		List<Statement> st = new ArrayList<Statement>();
 		st.add(goToInstallDir());
-		st.add(exec("su -c 'case $(head -n 1 " + installDir + "daemons) in *WORKER*) java -cp \"" + installDir + "sda/storm-deploy-alternative.jar\" dk.kaspergsm.stormdeploy.image.ProcessMonitor backtype.storm.daemon.supervisor " + installDir + "storm/bin/storm supervisor ;; esac &' - " + username));
+		st.add(exec("su -c 'case $(head -n 1 " + installDir + "daemons) in *WORKER*) java -cp \"" + installDir + "sda/storm-deploy-alternative.jar\" dk.kaspergsm.stormdeploy.image.ProcessMonitor org.apache.storm.daemon.supervisor " + installDir + "storm/bin/storm supervisor ;; esac &' - " + username));
 		return st;
 	}
 	
@@ -93,7 +94,7 @@ public class Storm {
 		String installDir = System.getProperty("install.dir");
 		List<Statement> st = new ArrayList<Statement>();
 		st.add(goToInstallDir());
-		st.add(exec("su -c 'case $(head -n 1 " + installDir + "daemons) in *UI*) java -cp \"" + installDir + "sda/storm-deploy-alternative.jar\" dk.kaspergsm.stormdeploy.image.ProcessMonitor backtype.storm.ui.core " + installDir + "storm/bin/storm ui ;; esac &' - " + username));
+		st.add(exec("su -c 'case $(head -n 1 " + installDir + "daemons) in *UI*) java -cp \"" + installDir + "sda/storm-deploy-alternative.jar\" dk.kaspergsm.stormdeploy.image.ProcessMonitor org.apache.storm.ui.core " + installDir + "storm/bin/storm ui ;; esac &' - " + username));
 		return st;
 	}
 	
@@ -104,7 +105,7 @@ public class Storm {
 		String installDir = System.getProperty("install.dir");
 		List<Statement> st = new ArrayList<Statement>();
 		st.add(goToInstallDir());
-		st.add(exec("su -c 'case $(head -n 1 " + installDir + "daemons) in *DRPC*) java -cp \"" + installDir + "sda/storm-deploy-alternative.jar\" dk.kaspergsm.stormdeploy.image.ProcessMonitor backtype.storm.daemon.drpc " + installDir + "storm/bin/storm drpc ;; esac &' - " + username));
+		st.add(exec("su -c 'case $(head -n 1 " + installDir + "daemons) in *DRPC*) java -cp \"" + installDir + "sda/storm-deploy-alternative.jar\" dk.kaspergsm.stormdeploy.image.ProcessMonitor org.apache.storm.daemon.drpc " + installDir + "storm/bin/storm drpc ;; esac &' - " + username));
 		return st;
 	}
 	
@@ -115,7 +116,7 @@ public class Storm {
 		String installDir = System.getProperty("install.dir");
 		List<Statement> st = new ArrayList<Statement>();
 		st.add(goToInstallDir());
-		st.add(exec("su -c 'case $(head -n 1 " + installDir + "daemons) in *LOGVIEWER*) java -cp \"" + installDir + "sda/storm-deploy-alternative.jar\" dk.kaspergsm.stormdeploy.image.ProcessMonitor backtype.storm.daemon.logviewer " + installDir + "storm/bin/storm logviewer ;; esac &' - " + username));
+		st.add(exec("su -c 'case $(head -n 1 " + installDir + "daemons) in *LOGVIEWER*) java -cp \"" + installDir + "sda/storm-deploy-alternative.jar\" dk.kaspergsm.stormdeploy.image.ProcessMonitor org.apache.storm.daemon.logviewer " + installDir + "storm/bin/storm logviewer ;; esac &' - " + username));
 		return st;
 	}
 	

--- a/src/dk/kaspergsm/stormdeploy/userprovided/Configuration.java
+++ b/src/dk/kaspergsm/stormdeploy/userprovided/Configuration.java
@@ -189,7 +189,11 @@ public class Configuration {
 		}
 		return null;
 	}
-	
+
+	public String getStormVersion(){
+		return getRawConfigValue("storm-version");
+	}
+
 	/**
 	 * Get the ssh key pair name
 	 */


### PR DESCRIPTION
This commit checks the storm version and adjusts the storm config and ProcessMonitor package names accordingly to support modifications made in storm 1.0.1

Part fixes #36 